### PR TITLE
Better clarification on the state of the book

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,10 +1,18 @@
+----------------
+
+# 🚧 Work in progress 🚧
+
+This book is largely incomplete. If you want to contribute, feel free to [join our Discord server](https://discord.gg/3xZJ65GAhd) and start a discussion there.
+
+While to book is being worked on, the best resources to get started with iced are:
+
+- The [API Reference](https://docs.iced.rs/iced/)
+- The [official examples](https://github.com/iced-rs/iced/tree/master/examples)
+- The codebase of [many open-source iced projects](https://github.com/iced-rs/iced/issues/355)
+
+----------------
+
 # Introduction
-
-**Warning: This book, like [iced] itself, is not yet complete and is a work in progress.  In the mean time please refer to the [API Reference](https://docs.rs/iced/latest/iced/) and look at the included [examples](https://github.com/iced-rs/iced/tree/master/examples) to learn more about iced.**
-
-If you want to help contribute then [pull requests](https://github.com/iced-rs/book) for this book are welcome.
-
-## Overview
 
 [iced] is a cross-platform GUI library for [Rust]. It is inspired by [Elm], a delightful functional language for building web applications.
 
@@ -25,3 +33,4 @@ Before proceeding, you should have some basic familiarity with Rust. If you are 
 [Elm]: https://elm-lang.org
 [graphical user interfaces]: https://en.wikipedia.org/wiki/Graphical_user_interface
 [the official Rust book]: https://doc.rust-lang.org/book/
+

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,11 @@
 # Introduction
 
+**Warning: This book, like [iced] itself, is not yet complete and is a work in progress.  In the mean time please refer to the [API Reference](https://docs.rs/iced/latest/iced/) and look at the included [examples](https://github.com/iced-rs/iced/tree/master/examples) to learn more about iced.**
+
+If you want to help contribute then [pull requests](https://github.com/iced-rs/book) for this book are welcome.
+
+## Overview
+
 [iced] is a cross-platform GUI library for [Rust]. It is inspired by [Elm], a delightful functional language for building web applications.
 
 As a GUI library, iced helps you build *[graphical user interfaces]* for your Rust applications.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,39 +2,39 @@
 
 - [Introduction](README.md)
 
-- [Architecture](architecture/README.md)
-  - [The Elm Architecture](architecture/the_elm_architecture.md)
-  - [The update and render cycle](architecture/the_update_and_render_cycle.md)
-  - [The iced ecosystem](architecture/the_iced_ecosystem.md)
+- [TODO: Architecture]()<!--(architecture/README.md)--> 
+  - [TODO: The Elm Architecture]()<!--(architecture/the_elm_architecture.md)-->
+  - [TODO: The update and render cycle]()<!--(architecture/the_update_and_render_cycle.md)-->
+  - [TODO: The iced ecosystem]()<!--(architecture/the_iced_ecosystem.md)-->
 
-- [Layout](layout/README.md)
-  - [Centering widgets](layout/centering_widgets.md)
-  - [Aligning widgets](layout/aligning_widgets.md)
+- [TODO: Layout]()<!--(layout/README.md)-->
+  - [TODO: Centering widgets]()<!--(layout/centering_widgets.md)-->
+  - [TODO: Aligning widgets]()<!--(layout/aligning_widgets.md)-->
 
-- [Styling](styling/README.md)
-  - [Styling widgets](styling/styling_widgets.md)
-  - [Using style sheets](styling/using_style_sheets.md)
-  - [Creating themes](styling/creating_themes.md)
+- [TODO: Styling]()<!--(styling/README.md)-->
+  - [TODO: Styling widgets]()<!--(styling/styling_widgets.md)-->
+  - [TODO: Using style sheets]()<!--(styling/using_style_sheets.md)-->
+  - [TODO: Creating themes]()<!--(styling/creating_themes.md)-->
 
-- [Runtime, Commands & Subscriptions](runtime/README.md)
-  - [The iced runtime](runtime/the_iced_runtime.md)
-  - [Leveraging async Rust](runtime/async.md)
-  - [Implementing custom subscriptions](runtime/implementing_subscriptions.md)
+- [TODO: Runtime, Commands & Subscriptions]()<!--(runtime/README.md)-->
+  - [TODO: The iced runtime]()<!--(runtime/the_iced_runtime.md)-->
+  - [TODO: Leveraging async Rust]()<!--(runtime/async.md)-->
+  - [TODO: Implementing custom subscriptions]()<!--(runtime/implementing_subscriptions.md)-->
 
-- [Scaling & Composability](scaling/README.md)
-  - [Splitting files](scaling/splitting_files.md)
-  - [Reusing logic](scaling/reusing_logic.md)
-  - [Managing big codebases](scaling/managing_codebases.md)
+- [TODO: Scaling & Composability]()<!--(scaling/README.md)-->
+  - [TODO: Splitting files]()<!--(scaling/splitting_files.md)-->
+  - [TODO: Reusing logic]()<!--(scaling/reusing_logic.md)-->
+  - [TODO: Managing big codebases]()<!--(scaling/managing_codebases.md)-->
 
-- [Debugging](debugging/README.md)
+- [TODO: Debugging]()<!--(debugging/README.md)-->
 
-- [Custom widgets](custom_widgets/README.md)
+- [TODO: Custom widgets]()<!--(custom_widgets/README.md)-->
 
-- [Compatibility](compatibility/README.md)
-  - [Platform differences](compatibility/platform_differences.md)
+- [TODO: Compatibility]()<!--(compatibility/README.md)-->
+  - [TODO: Platform differences]()<!--(compatibility/platform_differences.md)-->
 
-- [Integration](integration/README.md)
-  - [Developing custom renderers and shells](integration/extending_the_ecosystem.md)
-  - [Integrating iced into another framework or engine](integration/integrating_iced.md)
+- [TODO: Integration]()<!--(integration/README.md)-->
+  - [TODO: Developing custom renderers and shells]()<!--(integration/extending_the_ecosystem.md)-->
+  - [TODO: Integrating iced into another framework or engine]()<!--(integration/integrating_iced.md)-->
 
-- [Frequently Asked Questions](faq/README.md)
+- [TODO: Frequently Asked Questions]()<!--(faq/README.md)-->


### PR DESCRIPTION
Change the links in the summary that went to (mostly) empty chapters to
be inactive and append TODO: to the titles.  This mimics how incomplete
pages work on books like the Rust async book
https://rust-lang.github.io/async-book/

Also update the README.md to point people to the the examples and API
Reference so that those who came to the iced.rs main page and find
additional information

Fixes: #1 